### PR TITLE
bump up anndata dependency version to 0.7.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: zellkonverter
 Title: Conversion Between scRNA-seq Objects
 Version: 0.99.4
-Date: 2020-07-21
+Date: 2020-08-28
 Authors@R: 
     c(person(given = "Luke",
              family = "Zappia",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zellkonverter
 Title: Conversion Between scRNA-seq Objects
-Version: 0.99.3
+Version: 0.99.4
 Date: 2020-07-21
 Authors@R: 
     c(person(given = "Luke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # zellkonverter 1.0 (Bioconductor 3.12)
 
+## zellkonverter 0.99.4 (2020-08-28)
+
+* Bump anndata version to 0.7.4
+
 ## zellkonverter 0.99.3 (2020-08-21)
 
 * Document the `krumsiek11.h5ad` file

--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -24,7 +24,7 @@
 #' @export
 #' @name AnnDataDependencies
 .AnnDataDependencies <- c(
-    "anndata==0.7.3",
+    "anndata==0.7.4",
     "h5py==2.10.0",
     "hdf5==1.10.5",
     "natsort==7.0.1",


### PR DESCRIPTION
Currently, https://github.com/kevinrue/velociraptor fails `R CMD check` with error 
```
Quitting from lines 64-67 (userguide.Rmd) 
Error: processing vignette 'userguide.Rmd' failed with diagnostics:
ImportError: cannot import name 'concat' from 'anndata' (/github/home/.cache/basilisk/1.1.9/velociraptor-0.99.0/env/lib/python3.7/site-packages/anndata/__init__.py)
```

See https://github.com/kevinrue/velociraptor/runs/1043289251

Running `conda install anndata==0.7.4` in the basilisk/conda environment allowed `R CMD check` to pass successfully.

Which seems to make sense as https://anndata.readthedocs.io/en/latest/#id1 
mentions a new function `anndata.concat()`
